### PR TITLE
Update tm_shape.R

### DIFF
--- a/R/tm_shape.R
+++ b/R/tm_shape.R
@@ -12,6 +12,7 @@
 #'  \item{\code{\link[raster:Raster-class]{RasterLayer, RasterStack, or RasterBrick}}}
 #' }
 #' Simple features (\code{sf} objects) are also supported. For drawing layers \code{\link{tm_fill}} and \code{\link{tm_borders}}, 1 is required. For drawing layer \code{\link{tm_lines}}, 3 is required. Layers \code{\link{tm_symbols}} and \code{\link{tm_text}} accept 1 to 3. For layer \code{\link{tm_raster}}, 4, 5, or 6 is required.
+#' @shape.name string naming the shape group in the legend. Default value is the name of \code{shp}.
 #' @param is.master logical that determines whether this \code{tm_shape} is the master shape element. The bounding box, projection settings, and the unit specifications of the resulting thematic map are taken from the \code{tm_shape} element of the master shape object. By default, the first master shape element with a raster shape is the master, and if there are no raster shapes used, then the first \code{tm_shape} is the master shape element.
 #' @param projection Either a \code{\link[sp:CRS]{CRS}} object or a character value. If it is a character, it can either be a \code{PROJ.4} character string or a shortcut. See \code{\link[tmaptools:get_proj4]{get_proj4}} for a list of shortcut values. By default, the projection is used that is defined in the \code{shp} object itself, which can be obtained with \code{\link[tmaptools:get_projection]{get_projection}}.
 #' @param bbox bounding box. One of the following:
@@ -31,7 +32,7 @@
 #' @seealso \code{\link[tmaptools:read_shape]{read_shape}} to read ESRI shape files, \code{\link[tmaptools:set_projection]{set_projection}}, \href{../doc/tmap-nutshell.html}{\code{vignette("tmap-nutshell")}} 
 #' @example ./examples/tm_shape.R
 #' @return \code{\link{tmap-element}}
-tm_shape <- function(shp, 
+tm_shape <- function(shp, shape.name = NULL,
 					 is.master = NA,
 					 projection=NULL,
 					 bbox = NULL,
@@ -39,7 +40,7 @@ tm_shape <- function(shp,
 					 simplify = 1,
 					 line.center.type = c("segment", "midpoint"),
 					 ...) {
-	shp_name <- deparse(substitute(shp))[1]
+	shp_name <- ifelse(is.null(shape.name) == TRUE, deparse(substitute(shp))[1], shape.name)
 	g <- list(tm_shape=c(as.list(environment()), list(...)))
 	class(g) <- "tmap"
 	g


### PR DESCRIPTION
Hi Martijn,

First off, thank you so much for such an excellent package. I had been trying to migrate from ggplot to leaflet, but there was so much missing functionality, that I had begun to loose hope in being able to reproduce an interactive version of my work. The tmap package has been a great boon.

I wanted to plot several attributes on the same map and allow the user to use the legend to turn on and off layers as appropriate. An attribute to override the name of the shp object seems to solve the problem nicely. I must apologize in advance; I've never submitted a pull request before, so I could be going about this the entirely wrong way.

Cheers,
John


Code proposed (not sure my pull request will work)

tm_shape <-  function(shp, 
                         shape.name = NULL,
                         is.master = NA,
                         projection=NULL,
                         bbox = NULL,
                         unit = getOption("tmap.unit"),
                         simplify = 1,
                         line.center.type = c("segment", "midpoint"),
                         ...) {
  shp_name <- ifelse(is.null(shape.name) == TRUE, deparse(substitute(shp))[1], shape.name)
  g <- list(tm_shape=c(as.list(environment()), list(...)))
  class(g) <- "tmap"
  g
}

